### PR TITLE
Fix Error on App Initialization

### DIFF
--- a/config/initializers/access_control.rb
+++ b/config/initializers/access_control.rb
@@ -15,7 +15,9 @@ Workarea.configure do |config|
   basic_auth.exclude_routes.add("/media/*")
   basic_auth.exclude_routes.add("/product_images/*")
 
-  basic_auth.whitelisted_ips = Rack::Attack::ALERT_LOGIC_IP_ADDRESSES
+  if Rack::Attack.const_defined? :IGNORED_IP_ADDRESSES
+    basic_auth.whitelisted_ips = Rack::Attack::IGNORED_IP_ADDRESSES
+  end
 
   Workarea.config.basic_auth = basic_auth
 


### PR DESCRIPTION
This plugin causes an error on init with the latest Workarea version
because the `Rack::Attack::ALERT_LOGIC_IP_ADDRESSES` constant was
replaced with the more generic `Rack::Attack::IGNORED_IP_ADDRESSES`.
Since Basic Auth uses this constant for its own whitelist, app
initialization errors out.