### PR TITLE
Remove extraneous push in Release task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,13 +34,12 @@ desc "Release version #{Workarea::BasicAuth::VERSION} of the gem"
 task :release do
   host = "https://#{ENV['BUNDLE_GEMS__WEBLINC__COM']}@gems.weblinc.com"
 
-  #Rake::Task['workarea:changelog'].execute
-  #system 'git add CHANGELOG.md'
-  #system 'git commit -m "Update CHANGELOG"'
-  #system 'git push origin HEAD'
+  Rake::Task['workarea:changelog'].execute
+  system 'git add CHANGELOG.md'
+  system 'git commit -m "Update CHANGELOG"'
 
   system "git tag -a v#{Workarea::BasicAuth::VERSION} -m 'Tagging #{Workarea::BasicAuth::VERSION}'"
-  system 'git push --tags'
+  system 'git push origin HEAD --follow-tags'
 
   system "gem build workarea-basic_auth.gemspec"
   system "gem push workarea-basic_auth-#{Workarea::BasicAuth::VERSION}.gem"


### PR DESCRIPTION
We're running out of minutes in our GitHub actions due to duplicate pushes
during a release. This consolidates the two pushes into one.

No changelog

WORKAREA-148